### PR TITLE
Add support for Docker as an alternative build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:stretch-slim
+
+RUN apt-get update && apt-get install -y \ 
+    python \
+    subversion \
+    build-essential \
+    git-core \
+    libncurses5-dev \
+    zlib1g-dev \
+    gawk \
+    flex \
+    quilt \
+    libssl-dev \
+    xsltproc \
+    libxml-parser-perl \
+    mercurial \
+    bzr \
+    ecj \
+    cvs \
+    unzip \
+    git \
+    wget
+
+ENV SOURCE_DIR="/src"
+WORKDIR ${SOURCE_DIR}
+
+ENTRYPOINT ["/usr/bin/python", "gl_image"]

--- a/README.md
+++ b/README.md
@@ -5,13 +5,7 @@ Imagebuilder for GL.iNet devices. The Image Builder (previously called the Image
 ## System Requirements
 
 - x86_64 platform
-- Ubuntu or another linux distro
-- Download the build environment:
-
-```bash
-sudo apt-get update
-sudo apt-get install subversion build-essential git-core libncurses5-dev zlib1g-dev gawk flex quilt libssl-dev xsltproc libxml-parser-perl mercurial bzr ecj cvs unzip git wget
-```
+- Linux distribution (like ubuntu or debian) or macOS using Docker as build environment
 
 ## Usage
 
@@ -19,7 +13,14 @@ To build all the router firmwares, run **python2.7 gl_image -a**. To build a spe
 
 Run **python2.7 gl_image -h** to see more details and advanced options.
 
-## Complete Usage Example
+## Local build environment
+
+Install the following packages to prepare the build environment:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python subversion build-essential git-core libncurses5-dev zlib1g-dev gawk flex quilt libssl-dev xsltproc libxml-parser-perl mercurial bzr ecj cvs unzip git wget
+```
 
 To make an image for the **Mifi** with some extra packages included:
 
@@ -32,6 +33,37 @@ python2.7 gl_image -p mifi -e "openssh-sftp-server nano htop"
 The compiled image becomes: *bin/gl-mifi/openwrt-mifi-ar71xx-generic-gl-mifi-squashfs-sysupgrade.bin*
 
 For other firmwares, the compiled firmware file is in **/bin/<device_name>/**.
+
+## Docker build environment
+
+You can also use a docker container as build environment.
+
+Get the source code by cloning the git repository:
+
+```bash
+git clone https://github.com/gl-inet/imagebuilder.git
+cd imagebuilder
+```
+
+Build the docker image by running the following:
+
+```bash
+docker build --rm -t gl-inet/imagebuilder - < Dockerfile
+```
+
+To list all the possible firmware images names:
+
+```bash
+docker run -v "$(pwd)":/src gl-inet/imagebuilder -l
+```
+
+And to make an image for the **Mifi** with some extra packages included:
+
+```bash
+docker run -v "$(pwd)":/src gl-inet/imagebuilder -p mifi -e "openssh-sftp-server nano htop"
+```
+
+You'll find the compiled firmware image in *bin/gl-mifi/openwrt-mifi-ar71xx-generic-gl-mifi-squashfs-sysupgrade.bin* and **/bin/<device_name>/**.
 
 ## Advanced Configuration
 


### PR DESCRIPTION
Important changes:

- Added a Dockerfile based on `debian:stretch-slim` for using as an alternative build environment.
- Added some documentation and example usages to the README.md